### PR TITLE
ci: Improve vulnerability stance and scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,6 @@ jobs:
       contents: read
       security-events: write
     needs: [lint, test, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ RUN go install go.opentelemetry.io/collector/cmd/builder@v0.146.1
 WORKDIR /build
 COPY . .
 
-RUN builder --config=builder-config.yaml
+RUN CGO_ENABLED=0 builder --config=builder-config.yaml
 
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /build/dist/otelcol-iceberg /otelcol-iceberg
 


### PR DESCRIPTION
# Pull Request

## Description

Set the docker scan step to run on PR's so that you can see failures before they hit main
Address vulns by setting `CGO_ENABLED=0`

## Testing

Run `make up` and verified data was able to be queried:
<img width="629" height="567" alt="image" src="https://github.com/user-attachments/assets/abdd7668-8726-45c1-8c4c-6605ce2132f4" />

## Additional Context

Failed run: https://github.com/EnterpriseDB/icebergexporter/actions/runs/24498825442
