### PR TITLE
refactor: replace custom hex encoder with encoding/hex

### DIFF
--- a/internal/arrow/logs.go
+++ b/internal/arrow/logs.go
@@ -4,6 +4,8 @@
 package arrow
 
 import (
+	"encoding/hex"
+
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -77,7 +79,7 @@ func (c *LogsConverter) Convert(ld plog.Logs) (arrow.RecordBatch, error) {
 				if tid.IsEmpty() {
 					builder.Field(col).(*array.StringBuilder).AppendNull()
 				} else {
-					builder.Field(col).(*array.StringBuilder).Append(hex(tid[:]))
+					builder.Field(col).(*array.StringBuilder).Append(hex.EncodeToString(tid[:]))
 				}
 				col++
 
@@ -85,7 +87,7 @@ func (c *LogsConverter) Convert(ld plog.Logs) (arrow.RecordBatch, error) {
 				if sid.IsEmpty() {
 					builder.Field(col).(*array.StringBuilder).AppendNull()
 				} else {
-					builder.Field(col).(*array.StringBuilder).Append(hex(sid[:]))
+					builder.Field(col).(*array.StringBuilder).Append(hex.EncodeToString(sid[:]))
 				}
 				col++
 

--- a/internal/arrow/metrics.go
+++ b/internal/arrow/metrics.go
@@ -4,6 +4,8 @@
 package arrow
 
 import (
+	"encoding/hex"
+
 	arrowlib "github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -344,8 +346,8 @@ func exemplarsToJSON(exemplars pmetric.ExemplarSlice) string {
 		sid := e.SpanID()
 		m := map[string]any{
 			"time_unix_nano": int64(e.Timestamp()),
-			"trace_id":       hex(tid[:]),
-			"span_id":        hex(sid[:]),
+			"trace_id":       hex.EncodeToString(tid[:]),
+			"span_id":        hex.EncodeToString(sid[:]),
 		}
 		switch e.ValueType() {
 		case pmetric.ExemplarValueTypeDouble:

--- a/internal/arrow/traces.go
+++ b/internal/arrow/traces.go
@@ -4,6 +4,8 @@
 package arrow
 
 import (
+	"encoding/hex"
+
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -70,10 +72,10 @@ func (c *TracesConverter) Convert(td ptrace.Traces) (arrow.RecordBatch, error) {
 
 				// Span fields
 				tid := span.TraceID()
-				builder.Field(col).(*array.StringBuilder).Append(hex(tid[:]))
+				builder.Field(col).(*array.StringBuilder).Append(hex.EncodeToString(tid[:]))
 				col++
 				sid := span.SpanID()
-				builder.Field(col).(*array.StringBuilder).Append(hex(sid[:]))
+				builder.Field(col).(*array.StringBuilder).Append(hex.EncodeToString(sid[:]))
 				col++
 				appendOptionalString(builder.Field(col), span.TraceState().AsRaw())
 				col++
@@ -82,7 +84,7 @@ func (c *TracesConverter) Convert(td ptrace.Traces) (arrow.RecordBatch, error) {
 				if psid.IsEmpty() {
 					builder.Field(col).(*array.StringBuilder).AppendNull()
 				} else {
-					builder.Field(col).(*array.StringBuilder).Append(hex(psid[:]))
+					builder.Field(col).(*array.StringBuilder).Append(hex.EncodeToString(psid[:]))
 				}
 				col++
 
@@ -179,8 +181,8 @@ func linksToJSON(links ptrace.SpanLinkSlice) string {
 		tid := l.TraceID()
 		sid := l.SpanID()
 		m := map[string]any{
-			"trace_id":                 hex(tid[:]),
-			"span_id":                  hex(sid[:]),
+			"trace_id":                 hex.EncodeToString(tid[:]),
+			"span_id":                  hex.EncodeToString(sid[:]),
 			"trace_state":              l.TraceState().AsRaw(),
 			"dropped_attributes_count": l.DroppedAttributesCount(),
 		}
@@ -216,14 +218,4 @@ func appendOptionalString(b array.Builder, val string) {
 	} else {
 		sb.Append(val)
 	}
-}
-
-func hex(b []byte) string {
-	const hextable = "0123456789abcdef"
-	dst := make([]byte, len(b)*2)
-	for i, v := range b {
-		dst[i*2] = hextable[v>>4]
-		dst[i*2+1] = hextable[v&0x0f]
-	}
-	return string(dst)
 }


### PR DESCRIPTION
# Pull Request

## Description

replace custom hex encoder with encoding/hex

## Testing

Queried logs successfully:
```
memory D SELECT severity_text, body, attr_service_name
         FROM read_parquet(
           's3://otel-data/iceberg/otel_logs/data/'
           || getvariable('today') || '/*/*.parquet',
           hive_partitioning=true
         )
         LIMIT 10;
┌───────────────┬─────────────┬───────────────────┐
│ severity_text │    body     │ attr_service_name │
│    varchar    │   varchar   │      varchar      │
├───────────────┼─────────────┼───────────────────┤
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
│ Info          │ the message │ demo-service      │
└───────────────┴─────────────┴───────────────────┘
```

## Additional Context

N/A
